### PR TITLE
<link rel='~' href='~' /> を使えるようにする

### DIFF
--- a/src/views/index.pug
+++ b/src/views/index.pug
@@ -35,6 +35,8 @@ html
           script(src=v.path)
         when "style"
           link(rel="stylesheet", href=v.path)
+        when "link"
+          link(rel=v.rel, href=v.path)
     //- script
     //-   include ../assets/scripts/app.js
 


### PR DESCRIPTION
`- { type: 'link', rel: 'alternate', path: 'android-app://hoge/https/hoge.com', }`

的な感じです。