### PR TITLE
404 遷移対応

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "routeful": "0.0.8",
     "sclazy": "0.0.2",
     "socialink": "0.0.2",
-    "spat": "0.1.2",
+    "spat": "0.1.3",
     "underscore": "^1.8.3",
     "uuaa": "0.1.0",
     "vercom": "0.0.2",

--- a/src/assets/plugins/spat.js
+++ b/src/assets/plugins/spat.js
@@ -1,6 +1,6 @@
 
 /* 
- * spat 0.1.1
+ * spat 0.1.3
  * single page application framework for riot.js
  * MIT Licensed
  * 
@@ -323,8 +323,9 @@ riot.tag2('spat-nav', '<div class="spat-pages" ref="pages" onmousedown="{_swipes
         page.classList.add('spat-hide');
         page.classList.add('current');
         page.setAttribute('data-page-id', pageId);
-        this.refs.pages.appendChild(page);
         riot.mount(page, tagName);
+
+        this.refs.pages.appendChild(page);
       }
       else {
         cached = true;

--- a/src/assets/scripts/main.js
+++ b/src/assets/scripts/main.js
@@ -61,7 +61,17 @@
               helmeta.set( meta );
             }
           });
-          spat.nav.swap(tagName, req.params);
+
+          // try {
+            spat.nav.swap(tagName, req.params);
+          // }
+          // catch (err) {
+          //   console.error('error:', `${tagName} の mount に失敗しました`);
+          //   console.error(err);
+          //   // if (router.pages && router.pages['404']) {
+          //   //   spat.nav.swap(router.pages['404'].tag, req.params);
+          //   // }
+          // }
 
           // 初回だけ判定して入れ替える
           if (appElement) {

--- a/src/assets/scripts/main.js
+++ b/src/assets/scripts/main.js
@@ -44,8 +44,15 @@
 
           // fetch があれば fetch する
           spat.nav.one('swap', async (e) => {
-            var tag = e.currentPage._tag;
+            // 初回だけ判定して入れ替える
+            if (appElement) {
+              var tempElement = document.querySelector('[data-is=app]');
+              tempElement.parentNode.replaceChild(appElement, tempElement);
 
+              appElement = null;
+            }
+
+            var tag = e.currentPage._tag;
             if (tag.fetch) {
               var data = await tag.fetch({app, req, res});
               Object.keys(data).forEach(key => {
@@ -72,14 +79,6 @@
           //   //   spat.nav.swap(router.pages['404'].tag, req.params);
           //   // }
           // }
-
-          // 初回だけ判定して入れ替える
-          if (appElement) {
-            var tempElement = document.querySelector('[data-is=app]');
-            tempElement.parentNode.replaceChild(appElement, tempElement);
-
-            appElement = null;
-          }
 
           next();
         };

--- a/src/assets/scripts/main.js
+++ b/src/assets/scripts/main.js
@@ -69,16 +69,16 @@
             }
           });
 
-          // try {
+          try {
             spat.nav.swap(tagName, req.params);
-          // }
-          // catch (err) {
-          //   console.error('error:', `${tagName} の mount に失敗しました`);
-          //   console.error(err);
-          //   // if (router.pages && router.pages['404']) {
-          //   //   spat.nav.swap(router.pages['404'].tag, req.params);
-          //   // }
-          // }
+          }
+          catch (err) {
+            console.error('error:', `${tagName} の mount に失敗しました`);
+            console.error(err);
+            if (router.pages && router.pages['404']) {
+              spat.nav.swap(router.pages['404'].tag, req.params);
+            }
+          }
 
           next();
         };

--- a/src/server/routes.js
+++ b/src/server/routes.js
@@ -28,13 +28,21 @@ var includes = (function() {
 })();
 
 var getTagOutput = async (tagName, req, res) => {
-  var root = document.createElement(tagName);
+  var root = document.createElement('div');
+  root.setAttribute('class', 'spat-page');
+  
   try {
+    root.setAttribute('data-is', tagName);
     var tag = riot.mount(root)[0];
   }
   catch (err) {
     console.log(`error: ${tagName} の mount に失敗しました`.red);
     console.log(err);
+
+    if (clientRouter.pages && clientRouter.pages['404']) {
+      root.setAttribute('data-is', clientRouter.pages['404'].tag);
+      var tag = riot.mount(root)[0];
+    }
   }
 
   if (tag.fetch) {

--- a/src/views/index.pug
+++ b/src/views/index.pug
@@ -83,5 +83,4 @@ html
     div(data-is='app')
       div.app-body
         spat-nav
-          div.spat-pages
-            div.spat-page !{content}
+          div.spat-pages !{content}

--- a/test/app/assets/scripts/router.js
+++ b/test/app/assets/scripts/router.js
@@ -16,4 +16,10 @@
     }
   };
 
+  exports.pages = {
+    '404': {
+      tag: 'page-404',
+    },
+  };
+
 })(typeof exports === 'undefined' ? this.router = {} : exports);

--- a/test/app/tags/modules/module-tabbar.pug
+++ b/test/app/tags/modules/module-tabbar.pug
@@ -15,7 +15,7 @@ module-tabbar
 
     this.tabs = [
       { icon: 'home', link: '/' },
-      { icon: 'search', link: '/' },
+      { icon: 'search', link: '/search' },
       { icon: 'bookmark', link: '/' },
       { icon: 'menu', link: '/settings' },
     ];

--- a/test/app/tags/pages/page-404.pug
+++ b/test/app/tags/pages/page-404.pug
@@ -1,0 +1,4 @@
+page-404
+  div.s-full.f.fh.flex-column
+    h1.fs128 404
+    a(href='/') TOP へ

--- a/yarn.lock
+++ b/yarn.lock
@@ -280,7 +280,6 @@ base@^0.11.1:
 basic-auth@~2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/basic-auth/-/basic-auth-2.0.1.tgz#b998279bf47ce38344b4f3cf916d4679bbf51e3a"
-  integrity sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==
   dependencies:
     safe-buffer "5.1.2"
 
@@ -316,7 +315,6 @@ body-parser@1.18.3, body-parser@^1.18.3:
 boolbase@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
-  integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
 
 boom@2.x.x:
   version "2.10.1"
@@ -595,7 +593,6 @@ content-type@~1.0.4:
 cookie-parser@^1.4.3:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/cookie-parser/-/cookie-parser-1.4.3.tgz#0fe31fa19d000b95f4aadf1f53fdc2b8a203baa5"
-  integrity sha1-D+MfoZ0AC5X0qt8fU/3CuKIDuqU=
   dependencies:
     cookie "0.3.1"
     cookie-signature "1.0.6"
@@ -636,7 +633,6 @@ cryptiles@2.x.x:
 css-select@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/css-select/-/css-select-1.2.0.tgz#2b3a110539c5355f1cd8d314623e870b121ec858"
-  integrity sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=
   dependencies:
     boolbase "~1.0.0"
     css-what "2.1"
@@ -646,7 +642,6 @@ css-select@^1.1.0:
 css-what@2.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.2.tgz#c0876d9d0480927d7d4920dcd72af3595649554d"
-  integrity sha512-wan8dMWQ0GUeF7DGEPVjhHemVW/vy6xUYmFzRY8RYqgA0JtXC9rJmbScBjqSu6dg9q0lwPQy6ZAmJVr3PPTvqQ==
 
 cycle@1.0.x:
   version "1.0.3"
@@ -754,14 +749,12 @@ doctypes@^1.1.0:
 dom-converter@~0.2:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/dom-converter/-/dom-converter-0.2.0.tgz#6721a9daee2e293682955b6afe416771627bb768"
-  integrity sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==
   dependencies:
     utila "~0.4"
 
 dom-serializer@0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.1.0.tgz#073c697546ce0780ce23be4a28e293e40bc30c82"
-  integrity sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=
   dependencies:
     domelementtype "~1.1.1"
     entities "~1.1.1"
@@ -769,31 +762,26 @@ dom-serializer@0:
 domelementtype@1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.3.1.tgz#d048c44b37b0d10a7f2a3d5fee3f4333d790481f"
-  integrity sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==
 
 domelementtype@~1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.1.3.tgz#bd28773e2642881aec51544924299c5cd822185b"
-  integrity sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=
 
 domhandler@2.1:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-2.1.0.tgz#d2646f5e57f6c3bab11cf6cb05d3c0acf7412594"
-  integrity sha1-0mRvXlf2w7qxHPbLBdPArPdBJZQ=
   dependencies:
     domelementtype "1"
 
 domutils@1.1:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.1.6.tgz#bddc3de099b9a2efacc51c623f28f416ecc57485"
-  integrity sha1-vdw94Jm5ou+sxRxiPyj0FuzFdIU=
   dependencies:
     domelementtype "1"
 
 domutils@1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.5.1.tgz#dcd8488a26f563d61079e48c9f7b7e32373682cf"
-  integrity sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=
   dependencies:
     dom-serializer "0"
     domelementtype "1"
@@ -832,7 +820,6 @@ end-of-stream@~0.1.5:
 entities@~1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.2.tgz#bdfa735299664dfafd34529ed4f8522a275fea56"
-  integrity sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==
 
 errno@^0.1.1:
   version "0.1.7"
@@ -1456,7 +1443,6 @@ homedir-polyfill@^1.0.1:
 htmlparser2@~3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.3.0.tgz#cc70d05a59f6542e43f0e685c982e14c924a9efe"
-  integrity sha1-zHDQWln2VC5D8OaFyYLhTJJKnv4=
   dependencies:
     domelementtype "1"
     domhandler "2.1"
@@ -2216,7 +2202,6 @@ moment@^2.22.0:
 morgan@^1.9.1:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/morgan/-/morgan-1.9.1.tgz#0a8d16734a1d9afbc824b99df87e738e58e2da59"
-  integrity sha512-HQStPIV4y3afTiCYVxirakhlCfGkI161c76kKFca7Fk1JusM//Qeo1ej2XaMniiNeaZklMVrh3vTtIzpzwbpmA==
   dependencies:
     basic-auth "~2.0.0"
     debug "2.6.9"
@@ -2344,7 +2329,6 @@ npmlog@^4.0.2:
 nth-check@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-1.0.2.tgz#b2bd295c37e3dd58a3bf0700376663ba4d9cf05c"
-  integrity sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==
   dependencies:
     boolbase "~1.0.0"
 
@@ -2567,7 +2551,6 @@ preserve@^0.2.0:
 pretty-error@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/pretty-error/-/pretty-error-2.1.1.tgz#5f4f87c8f91e5ae3f3ba87ab4cf5e03b1a17f1a3"
-  integrity sha1-X0+HyPkeWuPzuoerTPXgOxoX8aM=
   dependencies:
     renderkid "^2.0.1"
     utila "~0.4"
@@ -2874,7 +2857,6 @@ remove-trailing-separator@^1.0.1:
 renderkid@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/renderkid/-/renderkid-2.0.2.tgz#12d310f255360c07ad8fde253f6c9e9de372d2aa"
-  integrity sha512-FsygIxevi1jSiPY9h7vZmBFUbAOcbYm9UwyiLNdVsLRs/5We9Ob5NMPbGYUTWiLq5L+ezlVdE0A8bbME5CWTpg==
   dependencies:
     css-select "^1.1.0"
     dom-converter "~0.2"
@@ -3271,9 +3253,9 @@ spat@0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/spat/-/spat-0.1.1.tgz#a96ea522bad7f6f5805e48c0bd59fada7d297312"
 
-spat@0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/spat/-/spat-0.1.2.tgz#13bf7ec446958fb9c097e3d589b05dd76b525c9d"
+spat@0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/spat/-/spat-0.1.3.tgz#780e2c6fbf493ed0da885c85cbe0e8e83b1e28aa"
 
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"
@@ -3597,7 +3579,6 @@ util-deprecate@~1.0.1:
 utila@^0.4.0, utila@~0.4:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/utila/-/utila-0.4.0.tgz#8a16a05d445657a3aea5eecc5b12a4fa5379772c"
-  integrity sha1-ihagXURWV6Oupe7MWxKk+lN5dyw=
 
 utile@0.3.x:
   version "0.3.0"


### PR DESCRIPTION
## 詳細

1. router の pages に 404 用の tag を設定
2. 存在しないタグを mount しようとしたら 1 の tag にフォールバック

## 課題

動的遷移時に 404 フォールバックするには spat の swap をエラーハンドリングする必要がある ... done

## 確認方法

- `$ cd test`
- `$ npm run dev`
- access to http://localhost:3000
- タブの search をクリック
- 404 が表示されれば ok
