### PR TITLE
routefulのstart前にspat-modalが使えるようにする

### DIFF
--- a/src/views/index.pug
+++ b/src/views/index.pug
@@ -84,3 +84,5 @@ html
       div.app-body
         spat-nav
           div.spat-pages !{content}
+      spat-modal
+      spat-toast


### PR DESCRIPTION
spalate.start(false)でmodalとtoastが使えなかったので使えるようにしました