### PR TITLE
initとstartの分離とリファクタ

### DIFF
--- a/src/assets/scripts/client.js
+++ b/src/assets/scripts/client.js
@@ -12,9 +12,6 @@
           }
         },
       },
-      onpopstate: function() {
-        spat.nav._back = app.routeful.isBack;
-      },
     },
     init: function() {
       // 全ての要素をクリックに反応するようにする
@@ -34,11 +31,6 @@
       // setup riot
       riot.util.tmpl.errorHandler = function() {};
 
-      // check back
-      if (this.config.onpopstate) {
-        window.addEventListener('popstate', this.config.onpopstate, false);
-      }
-
       app.routeful = Routeful();
 
       // mount tag
@@ -52,7 +44,7 @@
           helmeta.set( config.head );
     
           var tagName = typeof route.tag === 'function' ? route.tag(req, res) : route.tag;
-
+          spalate.checkBack();
           // fetch があれば fetch する
           spat.nav.one('swap', async (e) => {
             var tag = e.currentPage._tag;
@@ -102,6 +94,10 @@
 
     start: function() {
       app.routeful.exec();
+    },
+
+    checkBack: function() {
+      spat.nav._back = app.routeful.isBack;
     },
 
   };

--- a/src/assets/scripts/client.js
+++ b/src/assets/scripts/client.js
@@ -95,13 +95,13 @@
         cordovaPromise = cdv.init();
       }
 
-      return Promise.all([cordovaPromise]);
+      return Promise.all([cordovaPromise]).then(() => {
+        app.routeful.start(false);
+      });
     },
 
-    start: function(exec) {
-      // ルーティングイベントを実行するかどうかのフラグ(デフォルトは true)
-      exec = (exec === undefined) ? true : exec;
-      app.routeful.start(exec);
+    start: function() {
+      app.routeful.exec();
     },
 
   };

--- a/src/assets/scripts/client.js
+++ b/src/assets/scripts/client.js
@@ -1,31 +1,43 @@
 
 ;(function(global) {
   spalate = {
-    start: function(exec) {
-      // ルーティングイベントを実行するかどうかのフラグ(デフォルトは true)
-      exec = (exec === undefined) ? true : exec;
+    config: {
+      ref: {
+        onalways: function(req, res) {
 
+        },
+        onfail: function(req, res) {
+          if (res) {
+            spat.modal.alert(res.message || `エラーが発生しました。\n${JSON.stringify(res)}`, 'Error');
+          }
+        },
+      },
+      onpopstate: function() {
+        spat.nav._back = app.routeful.isBack;
+      },
+    },
+    init: function() {
       // 全ての要素をクリックに反応するようにする
       if (uuaa.os.name === 'iOS') {
         document.body.classList.add('cursor-pointer');
       }
-      // request 共通
-      app.ref.on('always', function(req, res) {
-
-      });
-      app.ref.on('fail', function(req, res) {
-        if (res) {
-          spat.modal.alert(res.message || `エラーが発生しました。\n${JSON.stringify(res)}`, 'Error');
+      if (this.config.ref) {
+        if (this.config.ref.onalways) {
+          // request 共通
+          app.ref.on('always', this.config.ref.onalways);
         }
-      });
+        if (this.config.ref.onfail) {
+          app.ref.on('fail', this.config.ref.onfail);
+        }
+      }
 
       // setup riot
       riot.util.tmpl.errorHandler = function() {};
 
       // check back
-      window.addEventListener('popstate', function(e) {
-        spat.nav._back = true;
-      }, false);
+      if (this.config.onpopstate) {
+        window.addEventListener('popstate', this.config.onpopstate, false);
+      }
 
       app.routeful = Routeful();
 
@@ -83,10 +95,15 @@
         cordovaPromise = cdv.init();
       }
 
-      return Promise.all([cordovaPromise]).then(() => {
-        app.routeful.start(exec);
-      });
+      return Promise.all([cordovaPromise]);
     },
+
+    start: function(exec) {
+      // ルーティングイベントを実行するかどうかのフラグ(デフォルトは true)
+      exec = (exec === undefined) ? true : exec;
+      app.routeful.start(exec);
+    },
+
   };
 
   global.spalate = spalate;

--- a/test/public/scripts/main.js
+++ b/test/public/scripts/main.js
@@ -1,4 +1,4 @@
-document.addEventListener('DOMContentLoaded', function() {
-  spalate.init();
+document.addEventListener('DOMContentLoaded', async function() {
+  await spalate.init();
   spalate.start();
 });

--- a/test/public/scripts/main.js
+++ b/test/public/scripts/main.js
@@ -1,3 +1,4 @@
 document.addEventListener('DOMContentLoaded', function() {
+  spalate.init();
   spalate.start();
 });


### PR DESCRIPTION
spalate.init()してからstart()しないといけないようにしました。
startは何度実行しても問題ないです。
デフォルトの挙動をカスタマイズできるようにしました

## 例

```

spalate.init().then(() => {
  spalate.start();
});

```